### PR TITLE
Report 0 exitcode when things are already installed (fixes #194)

### DIFF
--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -5,7 +5,11 @@ module XcodeInstall
       self.summary = 'Installs Xcode Command Line Tools.'
 
       def run
-        fail Informative, 'Xcode CLI Tools are already installed.' if installed?
+        if installed?
+          puts 'Xcode CLI Tools are already installed.'.ansi.yellow
+          exit
+        end
+
         install
       end
 

--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -6,7 +6,7 @@ module XcodeInstall
 
       def run
         if installed?
-          puts 'Xcode CLI Tools are already installed.'.ansi.yellow
+          puts '[!] Xcode CLI Tools are already installed.'.ansi.yellow
           exit
         end
 

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -35,7 +35,12 @@ module XcodeInstall
         super
 
         help! 'A VERSION argument is required.' unless @version
-        fail Informative, "Version #{@version} already installed." if @installer.installed?(@version) && !@force
+
+        if @installer.installed?(@version)
+          puts "[!] Version #{@version} already installed.".ansi.yellow
+          exit unless @force
+        end
+
         fail Informative, "Version #{@version} doesn't exist." unless @url || @installer.exist?(@version)
         fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
       end

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -17,31 +17,24 @@ module XcodeInstall
       end
 
       def run
-        @install ? install : list
+        @install ? install(matching_simulator) : list
       end
     end
 
     :private
 
-    def install
+    def matching_simulator
       filtered_simulators = @installed_xcodes.map(&:available_simulators).flatten.uniq(&:name).select do |sim|
         sim.name.start_with?(@install)
       end
+
       case filtered_simulators.count
       when 0
         puts "[!] No simulator matching #{@install} was found. Please specify a version from the following available simulators:".ansi.red
         list
         exit 1
       when 1
-        simulator = filtered_simulators.first
-
-        if simulator.installed?
-          puts "[!] #{simulator.name} is already installed.".ansi.yellow
-          exit
-        end
-
-        puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
-        simulator.install
+        return filtered_simulators.first
       else
         puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
         filtered_simulators.each do |candidate|
@@ -50,6 +43,16 @@ module XcodeInstall
         end
         exit 1
       end
+    end
+
+    def install(simulator)
+      if simulator.installed?
+        puts "[!] #{simulator.name} is already installed.".ansi.yellow
+        exit
+      end
+
+      puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
+      simulator.install
     end
 
     def list

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -34,7 +34,12 @@ module XcodeInstall
         exit 1
       when 1
         simulator = filtered_simulators.first
-        fail Informative, "#{simulator.name} is already installed." if simulator.installed?
+
+        if simulator.installed?
+          puts "[!] #{simulator.name} is already installed.".ansi.yellow
+          exit
+        end
+
         puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
         simulator.install
       else

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -4,7 +4,8 @@ module XcodeInstall
   describe Command::InstallCLITools do
     it 'fails if tools are already installed' do
       Command::InstallCLITools.any_instance.expects(:installed?).returns(true)
-      -> { Command::InstallCLITools.run }.should.raise(SystemExit)
+      Command::InstallCLITools.any_instance.expects(:exit).with.throws :exit
+      -> { Command::InstallCLITools.run }.should.throw(:exit)
     end
 
     it 'runs if tools are not installed' do

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -37,6 +37,13 @@ module XcodeInstall
       end
     end
 
+    it 'exists if version is already installed' do
+      Installer.any_instance.stubs(:installed?).with('6.3').returns(true)
+      Command::Install.any_instance.expects(:exit).with.throws :exit
+
+      -> { Command::Install.run(['6.3']) }.should.throw :exit
+    end
+
     it 'parses hdiutil output' do
       installer = Installer.new
       fixture = Pathname.new('spec/fixtures/hdiutil.plist').read

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -37,10 +37,9 @@ module XcodeInstall
       end
     end
 
-    it 'exists if version is already installed' do
+    it 'exits if version is already installed' do
       Installer.any_instance.stubs(:installed?).with('6.3').returns(true)
       Command::Install.any_instance.expects(:exit).with.throws :exit
-
       -> { Command::Install.run(['6.3']) }.should.throw :exit
     end
 

--- a/spec/simulators_spec.rb
+++ b/spec/simulators_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module XcodeInstall
+  describe Command::Simulators do
+    it 'exits if version is already installed' do
+      simulator = mock
+      simulator.stubs(:name).returns('nachOS 3.14')
+      simulator.stubs(:installed?).returns(true)
+      Command::Simulators.any_instance.stubs(:matching_simulator).returns(simulator)
+      Command::Simulators.any_instance.expects(:exit).with.throws :exit
+      -> { Command::Simulators.run(['--install="nachOS 3.14"']) }.should.throw :exit
+    end
+  end
+end


### PR DESCRIPTION
Saw that #194 was still open and fixed it.

- Added tests (and added new `simulators_spec`)
- Refactored `Command::Simulators` a bit to allow easier testing