### PR TITLE
Allow specification of local network cache URL

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -62,9 +62,9 @@ module XcodeInstall
       xcode = seedlist.find { |x| x.name == version } unless url
       dmg_file = Pathname.new(File.basename(url || xcode.path))
       result = false
-      if local_url != nil
-        local_url = local_url + dmg_file.to_s
-        result = Curl.new.fetch(local_url, CACHE_DIR, local_url ? nil : spaceship.cookie, dmg_file, progress)  
+      if !local_url.nil?
+        local_url += dmg_file.to_s
+        result = Curl.new.fetch(local_url, CACHE_DIR, local_url ? nil : spaceship.cookie, dmg_file, progress)
       end
       if result == false
         # Attempt download again using original url passed in.

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -62,7 +62,7 @@ module XcodeInstall
       xcode = seedlist.find { |x| x.name == version } unless url
       dmg_file = Pathname.new(File.basename(url || xcode.path))
       result = false
-      if !local_url.nil?
+      unless local_url.nil?
         local_url += dmg_file.to_s
         result = Curl.new.fetch(local_url, CACHE_DIR, local_url ? nil : spaceship.cookie, dmg_file, progress)
       end

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -16,7 +16,7 @@ module XcodeInstall
          ['--no-switch', 'Don’t switch to this version after installation'],
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.'],
-         ['--no-clean', 'Don’t delete DMG after insPtallation.'],
+         ['--no-clean', 'Don’t delete DMG after installation.'],
          ['--no-show-release-notes', 'Don’t open release notes in browser after installation.'],
          ['--cache-url-base', 'Base URL containing the Xcode DMG (e.g. "http://10.1.1.1/XcodeCache". Overrides --url unless a failure occurs.']].concat(super)
       end

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -16,8 +16,9 @@ module XcodeInstall
          ['--no-switch', 'Don’t switch to this version after installation'],
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.'],
-         ['--no-clean', 'Don’t delete DMG after installation.'],
-         ['--no-show-release-notes', 'Don’t open release notes in browser after installation.']].concat(super)
+         ['--no-clean', 'Don’t delete DMG after insPtallation.'],
+         ['--no-show-release-notes', 'Don’t open release notes in browser after installation.'],
+         ['--cache-url-base', 'Base URL containing the Xcode DMG (e.g. "http://10.1.1.1/XcodeCache". Overrides --url unless a failure occurs.']].concat(super)
       end
 
       def initialize(argv)
@@ -30,6 +31,7 @@ module XcodeInstall
         @should_switch = argv.flag?('switch', true)
         @progress = argv.flag?('progress', true)
         @show_release_notes = argv.flag?('show-release-notes', true)
+        @local_url = argv.option('cache-url-base')
         super
       end
 
@@ -40,11 +42,12 @@ module XcodeInstall
         fail Informative, "Version #{@version} already installed." if @installer.installed?(@version) && !@force
         fail Informative, "Version #{@version} doesn't exist." unless @url || @installer.exist?(@version)
         fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
+        fail Informative, "Invalid Cache URL: `#{@local_url}`" unless !@local_url || @local_url =~ /\A#{URI.regexp}\z/
       end
 
       def run
         @installer.install_version(@version, @should_switch, @should_clean, @should_install,
-                                   @progress, @url, @show_release_notes)
+                                   @progress, @url, @show_release_notes, @local_url)
       end
     end
   end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -12,26 +12,26 @@ module XcodeInstall
       end
 
       it 'downloads and installs' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3'])
       end
 
       it 'downloads and installs with custom HTTP URL' do
         url = 'http://yolo.com/xcode.dmg'
-        Installer.any_instance.expects(:download).with('6.3', true, url).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, url, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', "--url=#{url}"])
       end
 
       it 'downloads and installs and does not switch if --no-switch given' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', false, true)
         Command::Install.run(['6.3', '--no-switch'])
       end
 
       it 'downloads without progress if switch --no-progress is given' do
-        Installer.any_instance.expects(:download).with('6.3', false, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', false, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', '--no-progress'])
       end


### PR DESCRIPTION
_Preface: Please excuse my possibly horrid code; I am not a Ruby dev by trade and have little experience with it._

### Brief
Our company uses fastlane extensively (including `xcversion`) in a distributed environment, with each developer provided their own Mac. As a result we use `xcversion` to install the same version of Xcode on multiple Macs, however the set up prevents "imaging" each device.

In order to prevent multiple downloads of Xcode (especially in the middle of the day when the office LAN is congested) we required the ability to "cache" Xcode DMG/XIP files in a central location. This PR provides the option to includes a base URL that contains these cached files.

### Example Usage
Simply append `--cache-url-base=[INSERT_URL]` to the `xcversion` command, omitting the Xcode file name.

e.g. `xcversion install 9.3 --cache-url-base=http://10.1.1.15/XcodeCache`

### Related
Possibly a solution for issue #198 