### PR TITLE
Fixed loading of Fastlane::Actions::VerifyBuildAction

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -688,7 +688,7 @@ HELP
     end
 
     def verify_app_cert
-      cert_info = Fastlane::Actions::VerifyBuildAction.gather_cert_info(@path)
+      cert_info = Fastlane::Actions::VerifyBuildAction.gather_cert_info(@path.to_s)
       apple_team_identifier_result = cert_info['team_identifier'] == TEAM_IDENTIFIER
       apple_authority_result = cert_info['authority'].include?(AUTHORITY)
       apple_team_identifier_result && apple_authority_result

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -578,7 +578,7 @@ HELP
 
   class InstalledXcode
     TEAM_IDENTIFIER = '59GAB85EFG'.freeze
-    AUTHORITY = 'Apple Mac OS Application Signing'.freeze
+    AUTHORITY = 'Software Signing'.freeze
 
     attr_reader :path
     attr_reader :version

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -8,7 +8,8 @@ require 'xcode/install/command'
 require 'xcode/install/version'
 require 'shellwords'
 require 'open3'
-require 'fastlane/actions/actions_helper'
+require 'fastlane/action'
+require 'fastlane/actions/verify_build'
 
 module XcodeInstall
   CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")


### PR DESCRIPTION
This MR fixes various issues in the current master branch (commit#054d80a):

Currently on `master` branch the xcode install is failing cause constant `Fastlane::Actions::VerifyBuildAction` is not found.
Reason: requiring 'fastlane/actions/actions_helper' doesn't load actions automatically. We need to call `Fastlane::Actions.load_default_actions` to load all actions.

instead of loading all actions, I decided to just load `verify_build` action. Loading `verify_build` also requires `fastlane/action`, hence we are loading `fastlane/action` first, and then `fastlane/action/verify_build`.

There were two more bugs:
1. In `verify_app_cert` function, `Pathname` obj being passed to `VerifyBuildAction.get_cert_info`. Which resulted in error cause `VerifyBuildAction.get_cert_info` expects string obj.
1. cert verification is failing when xcode is not installed from AppStore. My fix is only valid for xcode 8 and onwards. Older versions of xcode have `teamIdentifier=not set`. I think the best way to do this is to use [VerifyXcodeAction](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/verify_xcode.rb) instead of VerifyBuildAction