### PR TITLE
Deletes all unavailable simulators after an xcode uninstall

### DIFF
--- a/lib/xcode/install/uninstall.rb
+++ b/lib/xcode/install/uninstall.rb
@@ -26,6 +26,7 @@ module XcodeInstall
         return if installed_path.nil? || installed_path.path.nil?
 
         `sudo rm -rf #{installed_path.path}`
+        `xcrun simctl delete unavailable`
 
         return unless @installer.symlinks_to == installed_path.path
         newest_version = @installer.installed_versions.last


### PR DESCRIPTION
In order to reduce disk space we should delete all unavailable simulators once an xcode version gets uninstalled.

I also had this in mind to do for an install as maybe developers remove their Xcode versions via the Finder - but it violates the single responsibility principle I guess. What do you think?