### PR TITLE
Using Fastlane::Actions::VerifyXcodeAction for verify_app_cert

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -8,8 +8,10 @@ require 'xcode/install/command'
 require 'xcode/install/version'
 require 'shellwords'
 require 'open3'
+require 'fastlane'
+require 'fastlane/helper/sh_helper'
 require 'fastlane/action'
-require 'fastlane/actions/verify_build'
+require 'fastlane/actions/verify_xcode'
 
 module XcodeInstall
   CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
@@ -576,9 +578,6 @@ HELP
   end
 
   class InstalledXcode
-    TEAM_IDENTIFIER = '59GAB85EFG'.freeze
-    AUTHORITY = 'Software Signing'.freeze
-
     attr_reader :path
     attr_reader :version
     attr_reader :bundle_version
@@ -687,10 +686,12 @@ HELP
     end
 
     def verify_app_cert
-      cert_info = Fastlane::Actions::VerifyBuildAction.gather_cert_info(@path.to_s)
-      apple_team_identifier_result = cert_info['team_identifier'] == TEAM_IDENTIFIER
-      apple_authority_result = cert_info['authority'].include?(AUTHORITY)
-      apple_team_identifier_result && apple_authority_result
+      begin
+        Fastlane::Actions::VerifyXcodeAction.run({ xcode_path: @path.to_s })
+      rescue
+        return false
+      end
+      true
     end
   end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -686,12 +686,10 @@ HELP
     end
 
     def verify_app_cert
-      begin
-        Fastlane::Actions::VerifyXcodeAction.run(xcode_path: @path.to_s)
-      rescue
-        return false
-      end
+      Fastlane::Actions::VerifyXcodeAction.run(xcode_path: @path.to_s)
       true
+    rescue
+      false
     end
   end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -687,7 +687,7 @@ HELP
 
     def verify_app_cert
       begin
-        Fastlane::Actions::VerifyXcodeAction.run({ xcode_path: @path.to_s })
+        Fastlane::Actions::VerifyXcodeAction.run(xcode_path: @path.to_s)
       rescue
         return false
       end


### PR DESCRIPTION
fix #360 

Current version of xcode-install (v2.6.1) can not install Xcode 10.x due to verify certificate step.

In #338 @salmanasiddiqui suggested using [VerifyXcodeAction](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/verify_xcode.rb) instead of VerifyBuildAction.
I tried his suggest and it works.

I confirmed in my forked repositories that this code fix can actually install Xcode 10.x.
https://github.com/Kesin11/xcode-install/runs/276027924

However, I know this fix is not better because it will be more dependent on fastlane. In addition,  additional logs that from VerifyXcodeAction have been displayed.

Another choice is only copy accepted codesign sets from [verify_xcode.rb](https://github.com/fastlane/fastlane/blob/2.134.0/fastlane/lib/fastlane/actions/verify_xcode.rb#L28-L50). 
Which choice should I take?