### PR TITLE
FIX InstalledXcode's bundle_version_string leading to wrong patch version

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -668,12 +668,11 @@ HELP
     :private
 
     def bundle_version_string
-      digits = plist_entry(':DTXcode').to_i.to_s
-      if digits.length < 3
-        digits.split(//).join('.')
-      else
-        "#{digits[0..-3]}.#{digits[-2]}.#{digits[-1]}"
+      bundle_version_components = plist_entry(':CFBundleShortVersionString').split('.')
+      while bundle_version_components.count < 3
+        bundle_version_components.add('0')
       end
+      return bundle_version_components.join('.')
     end
 
     def plist_entry(keypath)


### PR DESCRIPTION
I noticed that when trying to list or install iOS 13.0 simulators, they weren't listed when i ran `xcversion simulators`

Turns out that bundle_version_string had the wrong patch version (11.2.0 instead of 11.2.1), leading to a wrong list of simulator runtimes to be downloaded.

with this fix, i can finally install ios/tvos 13+ and watchos 6+