### PR TITLE
Adding Command Line Tools Installer (for all versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ to a dialog popping up. Feel free to dupe [the radar][5]. 📡
 
 XcodeInstall normally relies on the Spotlight index to locate installed versions of Xcode. If you use it while
 indexing is happening, it might show inaccurate results and it will not be able to see installed
-versions on unindexed volumes. 
+versions on unindexed volumes.
 
 To workaround the Spotlight limitation, XcodeInstall searches `/Applications` folder to locate Xcodes when Spotlight is disabled on the machine, or when Spotlight query for Xcode does not return any results. But it still won't work if your Xcodes are not located under `/Applications` folder.
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -379,7 +379,7 @@ HELP
                                               '/services-account/QH65B2/downloadws/listDownloads.action').body)
 
       names = @xcodes.map(&:name)
-      @xcodes += prereleases.reject { |pre| names.include?(pre.name) }
+      # @xcodes += prereleases.reject { |pre| names.include?(pre.name) }
 
       File.open(LIST_FILE, 'wb') do |f|
         f << Marshal.dump(xcodes)
@@ -442,10 +442,14 @@ HELP
 
         return [] if scan.empty?
 
-        version = scan.first.gsub(/<.*?>/, '').gsub(/.*Xcode /, '')
-        link = body.scan(%r{<button .*"(.+?.(dmg|xip))".*</button>}).first.first
-        notes = body.scan(%r{<a.+?href="(/go/\?id=xcode-.+?)".*>(.*)</a>}).first.first
-        links << Xcode.new(version, link, notes)
+        begin
+          version = scan.first.gsub(/<.*?>/, '').gsub(/.*Xcode /, '')
+          link = body.scan(%r{<button .*"(.+?.(dmg|xip))".*</button>}).first.first
+          notes = body.scan(%r{<a.+?href="(/go/\?id=xcode-.+?)".*>(.*)</a>}).first.first
+          links << Xcode.new(version, link, notes)
+        rescue StandardError => e
+          print "Error finding prerelease Xcode" + e
+        end
       end
 
       links

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -31,7 +31,6 @@ module XcodeInstall
               progress: nil,
               progress_block: nil)
       options = cookies.nil? ? [] : ['--cookie', cookies, '--cookie-jar', COOKIES_PATH]
-
       uri = URI.parse(url)
       output ||= File.basename(uri.path)
       output = (Pathname.new(directory) + Pathname.new(output)) if directory
@@ -329,7 +328,7 @@ HELP
       node.text
     end
 
-    private
+    #private
 
     def spaceship
       @spaceship ||= begin

--- a/lib/xcode/install/command.rb
+++ b/lib/xcode/install/command.rb
@@ -20,9 +20,10 @@ module XcodeInstall
     require 'xcode/install/list'
     require 'xcode/install/select'
     require 'xcode/install/selected'
+    require 'xcode/install/simulators'
+    require 'xcode/install/tools.rb'
     require 'xcode/install/uninstall'
     require 'xcode/install/update'
-    require 'xcode/install/simulators'
 
     self.abstract_command = true
     self.command = 'xcversion'

--- a/lib/xcode/install/tools.rb
+++ b/lib/xcode/install/tools.rb
@@ -29,33 +29,12 @@ module XcodeInstall
 
       :private
 
-      def download(package)
-        puts("Downloading #{package}")
-        url = 'https://developer.apple.com/devcenter/download.action?path=' + package
-        dmg_file = File.basename(url)
-        Curl.new.fetch(
-          url: url,
-          directory: XcodeInstall::CACHE_DIR,
-          cookies: @installer.spaceship.cookie,
-          output: dmg_file,
-          progress: false
-        )
-        XcodeInstall::CACHE_DIR + dmg_file
-      end
-
       def install
-        dmg_path = download(@install)
-        puts("Downloaded to from #{dmg_path}")
-        mount_dir = @installer.mount(dmg_path)
-        puts("Mounted to #{mount_dir}")
-        pkg_path = Dir.glob(File.join(mount_dir, '*.pkg')).first
-        puts("Installing from #{pkg_path}")
-        prompt = "Please authenticate to install Command Line Tools.\nPassword: "
-        `sudo -p "#{prompt}" installer -verbose -pkg "#{pkg_path}" -target /`
+        @installer.install_tools(@install)
       end
 
       def list
-        raise NotImplementedError, 'Listing is not implemented'
+        puts @installer.toolslist
       end
     end
   end

--- a/lib/xcode/install/tools.rb
+++ b/lib/xcode/install/tools.rb
@@ -1,5 +1,4 @@
 require 'claide'
-require 'spaceship'
 
 module XcodeInstall
   class Command
@@ -8,7 +7,7 @@ module XcodeInstall
       self.summary = 'List or install Xcode CLI tools.'
 
       def self.options
-        [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
+        [['--install=name', 'Install CLI tools with the name specified'],
          ['--force', 'Install even if the same version is already installed.'],
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.']].concat(super)

--- a/lib/xcode/install/tools.rb
+++ b/lib/xcode/install/tools.rb
@@ -1,0 +1,62 @@
+require 'claide'
+require 'spaceship'
+
+module XcodeInstall
+  class Command
+    class Tools < Command
+      self.command = 'tools'
+      self.summary = 'List or install Xcode CLI tools.'
+
+      def self.options
+        [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
+         ['--force', 'Install even if the same version is already installed.'],
+         ['--no-install', 'Only download DMG, but do not install it.'],
+         ['--no-progress', 'Don’t show download progress.']].concat(super)
+      end
+
+      def initialize(argv)
+        @install = argv.option('install')
+        @force = argv.flag?('force', false)
+        @should_install = argv.flag?('install', true)
+        @progress = argv.flag?('progress', true)
+        @installer = XcodeInstall::Installer.new
+        super
+      end
+
+      def run
+        @install ? install : list
+      end
+
+      :private
+
+      def download(package)
+        puts("Downloading #{package}")
+        url = 'https://developer.apple.com/devcenter/download.action?path=' + package
+        dmg_file = File.basename(url)
+        Curl.new.fetch(
+          url: url,
+          directory: XcodeInstall::CACHE_DIR,
+          cookies: @installer.spaceship.cookie,
+          output: dmg_file,
+          progress: false
+        )
+        XcodeInstall::CACHE_DIR + dmg_file
+      end
+
+      def install
+        dmg_path = download(@install)
+        puts("Downloaded to from #{dmg_path}")
+        mount_dir = @installer.mount(dmg_path)
+        puts("Mounted to #{mount_dir}")
+        pkg_path = Dir.glob(File.join(mount_dir, '*.pkg')).first
+        puts("Installing from #{pkg_path}")
+        prompt = "Please authenticate to install Command Line Tools.\nPassword: "
+        `sudo -p "#{prompt}" installer -verbose -pkg "#{pkg_path}" -target /`
+      end
+
+      def list
+        raise NotImplementedError, 'Listing is not implemented'
+      end
+    end
+  end
+end

--- a/lib/xcode/install/version.rb
+++ b/lib/xcode/install/version.rb
@@ -1,3 +1,3 @@
 module XcodeInstall
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end

--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   # contains spaceship, which is used for auth and dev portal interactions
   spec.add_dependency 'fastlane', '>= 2.1.0', '< 3.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
**Summary**

This supersedes #350 from @marcomorain as I used it as a base to work from on this idea.

The idea here is that while we can currently install the latest version of the CLI tools, this only installs the latest version via `softwareupdate` - this will always be the latest _stable_ version.

Where we are installing _beta_ versions of Xcode, we may wish to install the _beta_ CLI tools that go along with them. This is especially true in the beta images we create at CircleCI.

**Usage**

`xcversion tools` will list all version of CLI tools available to download and install:

<img width="717" alt="Screenshot 2020-02-26 at 15 41 27" src="https://user-images.githubusercontent.com/955076/75361011-8492fa00-58ae-11ea-8ba3-a7b6ff8524ab.png">

`xcversion tools --install="Command Line Tools for Xcode x.x.x"` will install the specified version (e.g., `xcversion tools --install="Command Line Tools for Xcode 11.2 beta 2"`)

<img width="1018" alt="screenshot_2020-02-20_at_11 59 11" src="https://user-images.githubusercontent.com/955076/75361551-64176f80-58af-11ea-961f-567e2c026c92.png">

**Implementation**

This is piggybacking on the implementation for grabbing Xcode information and downloading it.

Listing the tools will ping the api and parse it, saving a copy of the response to the cache file.

The installation will use the info from the api to find and download the specified tools version. It will then proceed to install by mounting the dmg and installing the pkg. This has a simple check to compare the tools version number we have downloaded to that the version which is installed after the install is complete, just as an extra step of verification (this check will only work on macOS 10.9 and above for now due to the change in the way the CLI tools are packaged)

This will possibly need merging with the current `cli.rb` and I intend to look into that soon, but thought I would open this PR now to get any feedback!