### PR TITLE
Fixes xcode version finder

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -168,8 +168,12 @@ module XcodeInstall
 
       seedlist.each do |current_seed|
         return current_seed if current_seed.name == version
+      end
+
+      seedlist.each do |current_seed|
         return current_seed if parsed_version && current_seed.version == parsed_version
       end
+      
       nil
     end
 

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -98,4 +98,24 @@ module XcodeInstall
       percentages.count.should.be.close(8, 4)
     end
   end
+
+  describe '#find_xcode_version' do
+    it 'should find the one with the matching name' do
+      installer = Installer.new
+
+      xcodes = [
+        XcodeInstall::Xcode.new('name' => '11.4 beta 2',
+          'files' => [{
+            'remotePath' => '/Developer_Tools/Xcode_11.4_beta_2/Xcode_11.4_beta_2.xip'
+          }]),
+        XcodeInstall::Xcode.new('name' => '11.4',
+          'files' => [{
+            'remotePath' => '/Developer_Tools/Xcode_11.4/Xcode_11.4.xip'
+          }])
+      ]
+
+      installer.stubs(:fetch_seedlist).returns(xcodes)
+      installer.find_xcode_version("11.4").name.should.be.equal("11.4")
+    end
+  end
 end


### PR DESCRIPTION
It was finding a beta version despite the release one being already available (11.4 beta instead of 11.4).
Now it tries to match the name first and when nothing matches it falls back to matching version.

Resolves xcpretty/xcode-install#381

Solution proposed here: https://github.com/xcpretty/xcode-install/issues/381#issuecomment-603812739.