### PR TITLE
Fix installed list can distinguish beta version

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -300,12 +300,16 @@ HELP
     end
 
     def list_annotated(xcodes_list)
-      installed = installed_versions.map(&:version)
-      xcodes_list.map do |x|
-        xcode_version = x.split(' ').first # exclude "beta N", "for Lion".
-        xcode_version << '.0' unless xcode_version.include?('.')
+      installed = installed_versions.map(&:appname_version)
 
-        installed.include?(xcode_version) ? "#{x} (installed)" : x
+      xcodes_list.map do |x|
+        xcode_version = x.split(' ') # split version and "beta N", "for Lion"
+        xcode_version[0] << '.0' unless xcode_version[0].include?('.')
+
+        # to match InstalledXcode.appname_version format
+        version = Gem::Version.new(xcode_version.join('.'))
+
+        installed.include?(version) ? "#{x} (installed)" : x
       end.join("\n")
     end
 
@@ -599,6 +603,12 @@ HELP
 
     def bundle_version
       @bundle_version ||= Gem::Version.new(bundle_version_string)
+    end
+
+    def appname_version
+      appname = @path.basename('.app').to_s
+      version_string = appname.split('-').last
+      Gem::Version.new(version_string)
     end
 
     def uuid

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -23,8 +23,9 @@ module XcodeInstall
     end
 
     def fake_installed_xcode(name)
-      xcode_path = "/Applications/Xcode-#{name}.app"
-      xcode_version = name
+      installed_name = name.split(' ').join('.')
+      xcode_path = "/Applications/Xcode-#{installed_name}.app"
+      xcode_version = name.split(' ').first
       xcode_version << '.0' unless name.include? '.'
 
       installed_xcode = InstalledXcode.new(xcode_path)
@@ -49,8 +50,20 @@ module XcodeInstall
     describe '#list_annotated' do
       it 'lists all versions with annotations' do
         fake_xcodes '1', '2.3', '2.3.1', '2.3.2', '3 some', '4.3.1 for Lion', '9.4.1', '10 beta'
-        fake_installed_xcodes '2.3', '4.3.1', '10'
+        fake_installed_xcodes '2.3', '4.3.1 for Lion', '10 beta'
         installer.list.should == "1\n2.3 (installed)\n2.3.1\n2.3.2\n3 some\n4.3.1 for Lion (installed)\n9.4.1\n10 beta (installed)"
+      end
+
+      it 'distinguish between beta and official_version' do
+        fake_xcodes '11.4', '11.4 beta'
+        fake_installed_xcodes '11.4'
+        installer.list.should == "11.4 (installed)\n11.4 beta"
+      end
+
+      it 'distinguish each beta versions' do
+        fake_xcodes '11.4 beta', '11.4 beta 3'
+        fake_installed_xcodes '11.4 beta'
+        installer.list.should == "11.4 beta (installed)\n11.4 beta 3"
       end
     end
   end


### PR DESCRIPTION
fix #384

# Problem
`xcversoin list` shows "InstalledXcode" list that has only version info and can not distinguish which are beta or not.
So if install the official version of Xcode 11.4, `xcversion list` shows also beta version of 11.4 is installed.

# Solution
Add a new version identifier to "InstalledXcode" that will be made from the name of the installed Xcode app. If Xcode 11.4 beta 3 installed by `xcversion install`, installed app name will be Xcode-11.4.beta.3.app. It is possible to determine if it is beta version or not.

Of course it won't correctly determine if the installed Xcode app is renamed, but I couldn't think of a better idea.
