### PR TITLE
Normalize Cached Xcode to lowercase string

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -373,7 +373,7 @@ HELP
       end
       if ENV.key?('XCODE_INSTALL_CACHE_DIR')
         Pathname.glob(ENV['XCODE_INSTALL_CACHE_DIR'] + '/*').each do |fpath|
-          return fpath if /^xcode_#{version}\.dmg|xip$/ =~ fpath.basename.to_s
+          return fpath if /^xcode_#{version}\.dmg|xip$/ =~ fpath.basename.to_s.downcase
         end
       end
 


### PR DESCRIPTION
Currently, Apple yields a file of the name Xcode_VERSION.xip. When
loading this file from a cache, xcversion should be able to pick that
up.

It simply picks up the cached file by using a lowercase version of the
string.