### PR TITLE
guard against an installed Xcode path without embedded version number

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -608,7 +608,12 @@ HELP
     def appname_version
       appname = @path.basename('.app').to_s
       version_string = appname.split('-').last
-      Gem::Version.new(version_string)
+      begin
+        Gem::Version.new(version_string)
+      rescue ArgumentError
+        puts 'Unable to determine Xcode version from path name, installed list may not correctly identify installed betas'
+        Gem::Version.new(nil)
+      end
     end
 
     def uuid


### PR DESCRIPTION
**This PR:**

Updates the `appname_version` method to catch cases in which the Xcode bundle has been renamed, in order to resolve #396.

Due to the updates in #386, `xcversion` commands will fail with the following error if the user renames the Xcode application bundle to remove the version number from the path, or if they've installed Xcode from another source, like the App Store.
```
version.rb:212:in `initialize': Malformed version number string Xcode (ArgumentError)
```

**Example repro/stacktrace:**
```
vagrant@xcode-from-apple-catalina-chef15 /Applications % ls
Safari.app	Utilities	Xcode-11.5.app
vagrant@xcode-from-apple-catalina-chef15 /Applications % /opt/chef/embedded/bin/xcversion update
vagrant@xcode-from-apple-catalina-chef15 /Applications % sudo mv ./Xcode-11.5.app ./Xcode.app
vagrant@xcode-from-apple-catalina-chef15 /Applications % /opt/chef/embedded/bin/xcversion update
Traceback (most recent call last):
	11: from /opt/chef/embedded/bin/xcversion:23:in `<main>'
	10: from /opt/chef/embedded/bin/xcversion:23:in `load'
	 9: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/bin/xcversion:12:in `<top (required)>'
	 8: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	 7: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/lib/xcode/install/update.rb:10:in `run'
	 6: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/lib/xcode/install.rb:317:in `list'
	 5: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/lib/xcode/install.rb:303:in `list_annotated'
	 4: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/lib/xcode/install.rb:303:in `map'
	 3: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/xcode-install-2.6.5/lib/xcode/install.rb:611:in `appname_version'
	 2: from /opt/chef/embedded/lib/ruby/2.6.0/rubygems/version.rb:203:in `new'
	 1: from /opt/chef/embedded/lib/ruby/2.6.0/rubygems/version.rb:203:in `new'
/opt/chef/embedded/lib/ruby/2.6.0/rubygems/version.rb:212:in `initialize': Malformed version number string Xcode (ArgumentError)
```

This change can impact proper detection of beta Xcode installations in the `xcversion installed` list, but only if the user has performed a Xcode bundle path rename. Given that the `CFBundleShortVersionString` from `Contents/version.plist` of beta Xcodes does not identify beta seeds directly, this is the only compromise I could think of that would allow for users to rename the Xcode application bundles installed by `xcode-install`.