### PR TITLE
Fix regexp in get_dmg method

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -380,7 +380,7 @@ HELP
       end
       if ENV.key?('XCODE_INSTALL_CACHE_DIR')
         Pathname.glob(ENV['XCODE_INSTALL_CACHE_DIR'] + '/*').each do |fpath|
-          return fpath if /^xcode_#{version}\.dmg|xip$/ =~ fpath.basename.to_s
+          return fpath if /^xcode_#{version}\.(dmg|xip)$/ =~ fpath.basename.to_s.downcase
         end
       end
 


### PR DESCRIPTION
# Issue

I found two issues in get_dmg regexp.

### 1. This does not matches upper case name.
Default downloaded xcode file name was `Xcode_${version}.xip`,
but this expression does not match this so the cache doesn't work properly.
Currently the cache seems to work because of right below issue, but not really...

### 2. without parentheses, the expression matches any xip extensions.

`/^xcode_#{version}\.dmg|xip$/` -> `/^xcode_#{version}\.dmg$/` or `/^xip$/` -> :x: (Any xip extension will matches this)
`/^xcode_#{version}\.(dmg|xip)$/` -> `/^xcode_#{version}\.dmg$/` or `/^xcode_#{version}\.xip$/` -> :o: What we are expected!

