### PR TITLE
Use injected `XCODE_INSTALL_CACHE_DIR`variable if exist.

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -14,7 +14,7 @@ require 'fastlane/action'
 require 'fastlane/actions/verify_xcode'
 
 module XcodeInstall
-  CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
+  CACHE_DIR = ENV["XCODE_INSTALL_CACHE_DIR"] || Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
   class Curl
     COOKIES_PATH = Pathname.new('/tmp/curl-cookies.txt')
 


### PR DESCRIPTION
Thank you for great library 😀


# Issue

We can specify the downloaded xcode folder with `ENV["XCODE_INSTALL_CACHE_DIR"]`
But when downloading not cached Xcode version, the file stored the default directory `#{ENV['HOME']}/Library/Caches/XcodeInstall`.
So to work local cache properly, I have to move xip file after download job done.

# Proposal

If user injected `XCODE_INSTALL_CACHE_DIR` variable, the install job executed under this path. 
