### PR TITLE
Feature/adding new cli option to define number of try for downloading DMG file

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -80,7 +80,7 @@ module XcodeInstall
       # "Partial file. Only a part of the file was transferred."
       # https://curl.haxx.se/mail/archive-2008-07/0098.html
       # https://github.com/KrauseFx/xcode-install/issues/210
-      number_of_try.times do
+      number_of_try.to_i.times do
         # Non-blocking call of Open3
         # We're not using the block based syntax, as the bacon testing
         # library doesn't seem to support writing tests for it

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -515,7 +515,7 @@ HELP
       end
     end
 
-    def download(progress, progress_block = nil, number_of_try = 3)
+    def download(progress, progress_block = nil, number_of_try)
       result = Curl.new.fetch(
         url: source,
         directory: CACHE_DIR,
@@ -526,8 +526,8 @@ HELP
       result ? dmg_path : nil
     end
 
-    def install(progress, should_install)
-      dmg_path = download(progress)
+    def install(progress, should_install, number_of_try)
+      dmg_path = download(progress, number_of_try)
       fail Informative, "Failed to download #{@name}." if dmg_path.nil?
 
       return unless should_install

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -17,7 +17,8 @@ module XcodeInstall
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.'],
          ['--no-clean', 'Don’t delete DMG after installation.'],
-         ['--no-show-release-notes', 'Don’t open release notes in browser after installation.']].concat(super)
+         ['--no-show-release-notes', 'Don’t open release notes in browser after installation.'],
+         ['--retry', 'How many times retry to download DMG file if fails. Default is 3.']].concat(super)
       end
 
       def initialize(argv)
@@ -31,6 +32,7 @@ module XcodeInstall
         @should_switch = argv.flag?('switch', true)
         @progress = argv.flag?('progress', true)
         @show_release_notes = argv.flag?('show-release-notes', true)
+        @number_of_try = argv.option('retry', 3)
         super
       end
 
@@ -48,7 +50,7 @@ module XcodeInstall
 
       def run
         @installer.install_version(@version, @should_switch, @should_clean, @should_install,
-                                   @progress, @url, @show_release_notes)
+                                   @progress, @url, @show_release_notes, @number_of_try)
       end
     end
   end

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -18,7 +18,7 @@ module XcodeInstall
          ['--no-progress', 'Don’t show download progress.'],
          ['--no-clean', 'Don’t delete DMG after installation.'],
          ['--no-show-release-notes', 'Don’t open release notes in browser after installation.'],
-         ['--retry', 'How many times retry to download DMG file if fails. Default is 3.']].concat(super)
+         ['--retry=number', 'How many times try to download DMG file if fails. Default is 3.']].concat(super)
       end
 
       def initialize(argv)

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -10,7 +10,8 @@ module XcodeInstall
         [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
          ['--force', 'Install even if the same version is already installed.'],
          ['--no-install', 'Only download DMG, but do not install it.'],
-         ['--no-progress', 'Don’t show download progress.']].concat(super)
+         ['--no-progress', 'Don’t show download progress.']],
+         ['--retry', 'How many times retry to download DMG file if fails. Default is 3.']].concat(super)
       end
 
       def initialize(argv)

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -11,7 +11,7 @@ module XcodeInstall
          ['--force', 'Install even if the same version is already installed.'],
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.'],
-         ['--retry', 'How many times retry to download DMG file if fails. Default is 3.']].concat(super)
+         ['--retry=number', 'How many times try to download DMG file if fails. Default is 3.']].concat(super)
       end
 
       def initialize(argv)
@@ -20,6 +20,7 @@ module XcodeInstall
         @force = argv.flag?('force', false)
         @should_install = argv.flag?('install', true)
         @progress = argv.flag?('progress', true)
+        @number_of_try = argv.option('retry', 3)
         super
       end
 
@@ -43,7 +44,7 @@ module XcodeInstall
         simulator = filtered_simulators.first
         fail Informative, "#{simulator.name} is already installed." if simulator.installed? && !@force
         puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
-        simulator.install(@progress, @should_install)
+        simulator.install(@progress, @should_install, @number_of_try)
       else
         puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
         filtered_simulators.each do |candidate|

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -10,7 +10,7 @@ module XcodeInstall
         [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
          ['--force', 'Install even if the same version is already installed.'],
          ['--no-install', 'Only download DMG, but do not install it.'],
-         ['--no-progress', 'Don’t show download progress.']],
+         ['--no-progress', 'Don’t show download progress.'],
          ['--retry', 'How many times retry to download DMG file if fails. Default is 3.']].concat(super)
       end
 

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../spec_helper', __FILE__)
 
 module XcodeInstall
@@ -22,6 +24,13 @@ module XcodeInstall
         Installer.any_instance.expects(:download).with('6.3', true, url, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', "--url=#{url}"])
+      end
+
+      it 'downloads with retry option set to 5' do
+        number_of_try = 5
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil, number_of_try).returns('/some/path')
+        Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true, number_of_try)
+        Command::Install.run(['6.3', "--retry=#{number_of_try}"])
       end
 
       it 'downloads and installs and does not switch if --no-switch given' do


### PR DESCRIPTION
There are several issues related to downloading the DMG file since it is a several gig file, downloading this file requires more than 3 retries. For my experience, I set to retry option 100 and it completed the downloading around 45th try. 

I added a CLI option to define how many times it tries to download the file. 

issues: 
- https://github.com/xcpretty/xcode-install/issues/390
- https://github.com/xcpretty/xcode-install/issues/305


## Xcode
### without `--retry`, default is 3
```bash
bash-3.2$ xcversion install 11.6

install 11.6
Available session is not valid any more. Continuing with normal login.
100   305  100   305    0     0    340      0 --:--:-- --:--:-- --:--:--   340%
100   305  100   305    0     0    340      0 --:--:-- --:--:-- --:--:--   340
100   305  100   305    0     0    340      0 --:--:-- --:--:-- --:--:--   340
  0 7770M    0 70.6M    0     0   488k      0  4:31:27  0:02:28  4:28:59     0%
curl: (18) transfer closed with 8074031871 bytes remaining to read
100   309  100   309    0     0    267      0  0:00:01  0:00:01 --:--:--   267%
100   305  100   305    0     0    154      0  0:00:01  0:00:01 --:--:--  297k
100   305  100   305    0     0    154      0  0:00:01  0:00:01 --:--:--  297k
100   305  100   305    0     0    154      0  0:00:01  0:00:01 --:--:--  297k
  1 7699M    1 77.4M    0     0   734k      0  2:58:51  0:01:47  2:57:04  533k%
curl: (18) transfer closed with 7992796651 bytes remaining to read
100   305  100   305    0     0    335      0 --:--:-- --:--:-- --:--:--  297k%
100   305  100   305    0     0    335      0 --:--:-- --:--:-- --:--:--  297k
100   305  100   305    0     0    335      0 --:--:-- --:--:-- --:--:--  297k
  0 7622M    0 73.9M    0     0   689k      0  3:08:39  0:01:49  3:06:50  862k%
curl: (18) transfer closed with 7915294483 bytes remaining to read
%[!] Failed to download Xcode 11.6.
bash-3.2$
```


### with `--retry=4` will try to dowload 4 times
```bash
bash-3.2$ xcversion install 11.6 --retry=4

install 11.6 --retry=4
Available session is not valid any more. Continuing with normal login.
100   309  100   309    0     0    278      0  0:00:01  0:00:01 --:--:--   278%
100   305  100   305    0     0    158      0  0:00:01  0:00:01 --:--:--  297k
100   305  100   305    0     0    158      0  0:00:01  0:00:01 --:--:--  297k
100   305  100   305    0     0    158      0  0:00:01  0:00:01 --:--:--  297k
  3 6372M    3  219M    0     0   651k      0  2:47:03  0:05:45  2:41:18 94185%
curl: (18) transfer closed with 6452085416 bytes remaining to read
100   305  100   305    0     0    304      0  0:00:01  0:00:01 --:--:--  297k%
  2 6153M    2  184M    0     0   479k      0  3:38:59  0:06:33  3:32:26  603k%
curl: (18) transfer closed with 6258910537 bytes remaining to read
100   309  100   309    0     0    409      0 --:--:-- --:--:-- --:--:--   409%
100   309  100   309    0     0    409      0 --:--:-- --:--:-- --:--:--   409
100   305  100   305    0     0    193      0  0:00:01  0:00:01 --:--:--  297k
100   305  100   305    0     0    193      0  0:00:01  0:00:01 --:--:--  297k
  4 5968M    4  276M    0     0   705k      0  2:24:22  0:06:40  2:17:42  628k%
curl: (18) transfer closed with 5969205301 bytes remaining to read
100   309  100   309    0     0    414      0 --:--:-- --:--:-- --:--:--   414%
100   305  100   305    0     0    266      0  0:00:01  0:00:01 --:--:--   266
100   305  100   305    0     0    266      0  0:00:01  0:00:01 --:--:--   266
  3 5692M    3  227M    0     0   733k      0  2:12:32  0:05:17  2:07:15  667k%
curl: (18) transfer closed with 5731145963 bytes remaining to read
%[!] Failed to download Xcode 11.6.
bash-3.2$
```


## Simulator
### without `--retry`, default is 3
```bash
bash-3.2$ xcversion simulators --install='iOS 11.0 Simulator'

simulators --install=iOS 11.0 Simulator
  9 1989M    9  189M    0     0  1677k      0  0:20:14  0:01:55  0:18:19 1805k%
curl: (18) transfer closed with 1886829804 bytes remaining to read
  5 1799M    5  105M    0     0  1697k      0  0:18:05  0:01:03  0:17:02 1811k%
curl: (18) transfer closed with 1776103408 bytes remaining to read
  9 1693M    9  163M    0     0  1590k      0  0:18:10  0:01:45  0:16:25 1541k%
curl: (18) transfer closed with 1604346613 bytes remaining to read
%[!] Failed to download iOS 11.0 Simulator.
```


### with `--retry=5` will try to dowload 5 times
```bash
bash-3.2$ xcversion simulators --install='iOS 10.3.1 Simulator' --retry=5

simulators --install=iOS 10.3.1 Simulator --retry=5
 13 1198M   13  164M    0     0   717k      0  0:28:30  0:03:54  0:24:36  861k%
curl: (18) transfer closed with 1084795514 bytes remaining to read
 34  865M   34  298M    0     0  1421k      0  0:10:23  0:03:34  0:06:49 1855k%
curl: (18) transfer closed with 595033804 bytes remaining to read
 31  528M   31  163M    0     0  1653k      0  0:05:27  0:01:41  0:03:46 1737k%
curl: (18) transfer closed with 381830355 bytes remaining to read
 45  364M   45  163M    0     0  1194k      0  0:05:12  0:02:20  0:02:52  354k%
curl: (18) transfer closed with 209942487 bytes remaining to read
 53  200M   53  107M    0     0  1510k      0  0:02:15  0:01:12  0:01:03 1760k%
curl: (18) transfer closed with 97659610 bytes remaining to read
%[!] Failed to download iOS 10.3.1 Simulator.
bash-3.2$
```