### PR TITLE
fixing the cli option retry_download_count to support simulator

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -59,7 +59,7 @@ module XcodeInstall
       progress_log_file = File.join(CACHE_DIR, "progress.#{Time.now.to_i}.progress")
       FileUtils.rm_f(progress_log_file)
 
-      retry_options = ['--retry', '3']
+      retry_options = ['--retry', retry_download_count]
       command = [
         'curl',
         '--disable',

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -10,7 +10,8 @@ module XcodeInstall
         [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
          ['--force', 'Install even if the same version is already installed.'],
          ['--no-install', 'Only download DMG, but do not install it.'],
-         ['--no-progress', 'Don’t show download progress.']].concat(super)
+         ['--no-progress', 'Don’t show download progress.'],
+         ['--retry-download-count', 'Count of retrying download when curl is failed.']].concat(super)
       end
 
       def initialize(argv)
@@ -19,6 +20,7 @@ module XcodeInstall
         @force = argv.flag?('force', false)
         @should_install = argv.flag?('install', true)
         @progress = argv.flag?('progress', true)
+        @retry_download_count = argv.option('retry-download-count', '3')
         super
       end
 
@@ -42,7 +44,7 @@ module XcodeInstall
         simulator = filtered_simulators.first
         fail Informative, "#{simulator.name} is already installed." if simulator.installed? && !@force
         puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
-        simulator.install(@progress, @should_install)
+        simulator.install(@progress, @should_install, @retry_download_count.to_i)
       else
         puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
         filtered_simulators.each do |candidate|


### PR DESCRIPTION
## Simulator
### without `--retry_download_count`, default is 3
```bash
bash-3.2$ xcversion simulators --install='iOS 11.0 Simulator'

simulators --install=iOS 11.0 Simulator
  9 1989M    9  189M    0     0  1677k      0  0:20:14  0:01:55  0:18:19 1805k%
curl: (18) transfer closed with 1886829804 bytes remaining to read
  5 1799M    5  105M    0     0  1697k      0  0:18:05  0:01:03  0:17:02 1811k%
curl: (18) transfer closed with 1776103408 bytes remaining to read
  9 1693M    9  163M    0     0  1590k      0  0:18:10  0:01:45  0:16:25 1541k%
curl: (18) transfer closed with 1604346613 bytes remaining to read
%[!] Failed to download iOS 11.0 Simulator.
```


### with `--retry-download-count=5` will try to dowload 5 times
```bash
bash-3.2$ xcversion simulators --install='iOS 10.3.1 Simulator' --retry=5

simulators --install=iOS 10.3.1 Simulator --retry=5
 13 1198M   13  164M    0     0   717k      0  0:28:30  0:03:54  0:24:36  861k%
curl: (18) transfer closed with 1084795514 bytes remaining to read
 34  865M   34  298M    0     0  1421k      0  0:10:23  0:03:34  0:06:49 1855k%
curl: (18) transfer closed with 595033804 bytes remaining to read
 31  528M   31  163M    0     0  1653k      0  0:05:27  0:01:41  0:03:46 1737k%
curl: (18) transfer closed with 381830355 bytes remaining to read
 45  364M   45  163M    0     0  1194k      0  0:05:12  0:02:20  0:02:52  354k%
curl: (18) transfer closed with 209942487 bytes remaining to read
 53  200M   53  107M    0     0  1510k      0  0:02:15  0:01:12  0:01:03 1760k%
curl: (18) transfer closed with 97659610 bytes remaining to read
%[!] Failed to download iOS 10.3.1 Simulator.
bash-3.2$
```