### PR TITLE
Fix Installer's installed? method

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -186,7 +186,12 @@ module XcodeInstall
     end
 
     def installed?(version)
-      installed_versions.map(&:version).include?(version)
+      comparable_version = Gem::Version.new(version)
+      !installed_versions.find do |installed_xcode|
+        Gem::Version.new(installed_xcode.version) == comparable_version
+      end.nil?
+    rescue
+      false
     end
 
     def installed_versions


### PR DESCRIPTION
Hi!

First of all, thank you very much for a such great tool! It really helps to automate Xcode install/update process and saves a lot of time!

### Issue

I use `Fastlane` as automation tool and [xcode_install](https://docs.fastlane.tools/actions/xcode_install/) action to check and install `Xcode` versions. Usually only initial `Xcode` installation takes some time and all subsequent executions complete instantly with some message saying that `Xcode` with that version is already installed.

But once `Xcode 12` was released something became broken and even though `Xcode 12` was already installed the tool was installing it each time script was executed.

### Root cause

During investigation It turned out that even though `InstalledXcode` object with version equal to `'12.0'` existed in the list of installed versions, `Installer`'s `installed?` method was returning `false` instead of `true` for input values such as `'12'` or `'12.0.0'`. 

`installed?` was using simple `include?` method to check if input version exists in the collection of installed versions. Because `include?` is basically plain check for equality the logic was working for input such as `'12.0'` but was broken for any other input versions such as `'12'` or `'12.0.0'`.

### Fix

Even though string objects such as `'12'`,` '12.0'` and `'12.0.0'` are different, from version semantics perspective they are equal.

The solution is to avoid using simple comparison for strings which represent version and use `Version` abstraction instead. 

This pull request introduces the fix along with specs which cover some edge cases for malformed versions and makes sure that fix is backward compatible.

I would be happy to get any feedback.

Thank you!
