### PR TITLE
fix `.xcode-version` file read when it has whitespaces

### DIFF
--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -24,7 +24,7 @@ module XcodeInstall
       def initialize(argv)
         @installer = Installer.new
         @version = argv.shift_argument
-        @version ||= File.read('.xcode-version') if File.exist?('.xcode-version')
+        @version ||= File.read('.xcode-version').strip if File.exist?('.xcode-version')
         @url = argv.option('url')
         @force = argv.flag?('force', false)
         @should_clean = argv.flag?('clean', true)


### PR DESCRIPTION
Resolves https://github.com/xcpretty/xcode-install/issues/421

This PR simply trims whitespaces around the file read.

I was misled by these docs https://github.com/fastlane/ci/blob/master/docs/xcode-version.md#file-content that xcode-install would strip whitespaces, but it actually doesn't (yet), and caused that very misleading behavior (which also happens to be extremely hard to debug or notice because visually - on Terminal - it never prints the trailing whitespaces 😬 ).

I tried adding a unit test to cover this case, but honestly I couldn't make it work. This is what I ended up with, in `spec/install_spec.rb`:

```ruby
it 'reads .xcode-version and trim whitespaces if needed' do
  Installer.any_instance.expects(:download).with('6.3', true, nil, nil, 3).returns('/some/path')
  Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
  File.expects(:exist?).with('.xcode-version').returns(true)
  File.expects(:read).with('.xcode-version').returns('6.3\n')
  Command::Install.run([])
end
```

