### PR TITLE
Add documentation for the `.xcode-version` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ $ xcversion list
 
 They have to be installed using the full name, e.g. `xcversion install '7 GM seed'`.
 
+#### `.xcode-version`
+
+We recommend the creation of a `.xcode-version` file to explicitly declare and store the Xcode version to be used by your CI environment as well as your team.
+
+```
+12.5
+```
+
+Read [the proposal](/XCODE_VERSION.md) of `.xcode-version`.
+
 ### Select
 
 To see the currently selected version, run
@@ -151,7 +161,7 @@ to a dialog popping up. Feel free to dupe [the radar][5]. 📡
 
 XcodeInstall normally relies on the Spotlight index to locate installed versions of Xcode. If you use it while
 indexing is happening, it might show inaccurate results and it will not be able to see installed
-versions on unindexed volumes. 
+versions on unindexed volumes.
 
 To workaround the Spotlight limitation, XcodeInstall searches `/Applications` folder to locate Xcodes when Spotlight is disabled on the machine, or when Spotlight query for Xcode does not return any results. But it still won't work if your Xcodes are not located under `/Applications` folder.
 

--- a/XCODE_VERSION.md
+++ b/XCODE_VERSION.md
@@ -1,0 +1,49 @@
+# `.xcode-version`
+
+## Introduction
+
+This is a proposal for a new standard for the iOS community: a text-based file that defines the Xcode version to use to compile and package a given iOS project.
+
+This will be used by this gem, however it's designed in a way that any tool in the future can pick it up, no matter if it's Ruby based, Swift, JavaScript, etc.
+
+Similar to the [.ruby-version file](https://en.wikipedia.org/wiki/Ruby_Version_Manager), the `.xcode-version` file allows any CI system or IDE to automatically install and switch to the Xcode version needed for a given project to successfully compile your project.
+
+## Filename
+
+The filename must always be `.xcode-version`.
+
+## File location
+
+The file must be located in the same directory as your Xcode project/workspace, and you should add it to your versioning system (e.g. git).
+
+## File content
+
+The file content must be a simple string in a text file. The file may or may not end with an empty new line, this gem is responsible for stripping out the trailing `\n` (if used).
+
+### Sample files
+
+To define an official Xcode release
+
+```
+9.3
+```
+
+```
+7.2.1
+```
+
+You can also use pre-releases
+
+```
+11.5 GM Seed
+```
+
+```
+12 beta 6
+```
+
+Always following the same version naming listed by `xcversion list`.
+
+**Note**: Be aware that pre-releases might be eventually taken down from Apple's servers, meaning that it won't allow you to have fully reproducible builds as you won't be able to download the Xcode release once it's gone.
+
+It is recommended to only use non-beta releases in an `.xcode-version` file to have fully reproducible builds that you'll be able to run in a few years also.


### PR DESCRIPTION
This document was largely copied by the now-archived fastlane.ci repository: https://github.com/fastlane/ci/blob/master/docs/xcode-version.md

I trimmed down the unnecessary parts, and updated wording here and there where I found necessary.

I believe we should still try and make this a standard in the iOS community, hence why I'm creating this PR, to give a bit more life and exposure to this great feature.