### PR TITLE
Fix #426: filter Xcode versions

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -320,8 +320,15 @@ HELP
       end.join("\n")
     end
 
-    def list
-      list_annotated(list_versions.sort { |first, second| compare_versions(first, second) })
+    def list(requirement = nil)
+      versions = list_versions
+
+      unless requirement.nil?
+        req = Gem::Requirement.new(requirement.split(','))
+        versions.select! { |ver| req =~ Gem::Version.new(ver.split(' ')[0])}
+      end
+
+      list_annotated(versions.sort { |first, second| compare_versions(first, second) })
     end
 
     def rm_list_cache

--- a/lib/xcode/install/list.rb
+++ b/lib/xcode/install/list.rb
@@ -5,12 +5,19 @@ module XcodeInstall
       self.summary = 'List Xcodes available for download.'
 
       def self.options
-        [['--all', 'Show all available versions. (Default, Deprecated)']].concat(super)
+        [['--all', 'Show all available versions. (Default, Deprecated)'],
+         ['--filter', 'Filter by version requirement, e.g. "~> 12.0", or ">= 12.0, < 13.0"']].concat(super)
+      end
+
+      def initialize(argv)
+        @all = argv.flag?('all', true)
+        @filter = argv.option('filter')
+        super
       end
 
       def run
         installer = XcodeInstall::Installer.new
-        puts installer.list
+        puts installer.list(@filter)
       end
     end
   end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -46,6 +46,12 @@ module XcodeInstall
         installer.list.should == "1\n2.3\n2.3.1\n2.3.2\n3 some\n4 beta\n10 beta"
       end
 
+      it 'lists all versions filtered by requirements' do
+        fake_xcodes '1', '2.3', '2.3.1', '2.3.2', '3 some', '4 beta', '10 beta'
+        fake_installed_xcodes
+        installer.list('>= 2.0, < 10.0').should == "2.3\n2.3.1\n2.3.2\n3 some\n4 beta"
+      end
+
       it 'lists all versions in the correct order' do
         fake_xcodes(
           '12 beta 4', '12 beta 3', '12 beta 2', '12 for macOS Universal Apps beta 2',


### PR DESCRIPTION
Added a `filter` option to `xcversion list` command to filter Xcode versions, whose value is [gem version patterns](https://guides.rubygems.org/patterns/) joined by comma.

I believe this PR also fixed a wired error message on current version:
```
$ xcversion list --all
[!] Unknown option: `--all`
Did you mean: --all?

......
```