### PR TITLE
Allow specification of local network cache URL

### DIFF
--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -18,6 +18,7 @@ module XcodeInstall
          ['--no-progress', 'Don’t show download progress.'],
          ['--no-clean', 'Don’t delete DMG after installation.'],
          ['--no-show-release-notes', 'Don’t open release notes in browser after installation.'],
+         ['--cache-url-base', 'Base URL containing the Xcode DMG (e.g. "http://10.1.1.1/XcodeCache". Overrides --url unless a failure occurs.'],
          ['--retry-download-count', 'Count of retrying download when curl is failed.']].concat(super)
       end
 
@@ -33,6 +34,7 @@ module XcodeInstall
         @progress = argv.flag?('progress', true)
         @show_release_notes = argv.flag?('show-release-notes', true)
         @retry_download_count = argv.option('retry-download-count', '3')
+        @local_url = argv.option('cache-url-base')
         super
       end
 
@@ -46,12 +48,13 @@ module XcodeInstall
         end
         fail Informative, "Version #{@version} doesn't exist." unless @url || @installer.exist?(@version)
         fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
+        fail Informative, "Invalid Cache URL: `#{@local_url}`" unless !@local_url || @local_url =~ /\A#{URI.regexp}\z/
         fail Informative, "Invalid Retry: `#{@retry_download_count} is not positive number.`" if (@retry_download_count =~ /\A[0-9]*\z/).nil?
       end
 
       def run
         @installer.install_version(@version, @should_switch, @should_clean, @should_install,
-                                   @progress, @url, @show_release_notes, nil, @retry_download_count.to_i)
+                                   @progress, @url, @show_release_notes, @local_url, nil, @retry_download_count.to_i)
       end
     end
   end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -12,26 +12,26 @@ module XcodeInstall
       end
 
       it 'downloads and installs' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil, nil, 3).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil, nil, 3).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3'])
       end
 
       it 'downloads and installs with custom HTTP URL' do
         url = 'http://yolo.com/xcode.dmg'
-        Installer.any_instance.expects(:download).with('6.3', true, url, nil, 3).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, url, nil, nil, 3).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', "--url=#{url}"])
       end
 
       it 'downloads and installs and does not switch if --no-switch given' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil, nil, 3).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil, nil, 3).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', false, true)
         Command::Install.run(['6.3', '--no-switch'])
       end
 
       it 'downloads without progress if switch --no-progress is given' do
-        Installer.any_instance.expects(:download).with('6.3', false, nil, nil, 3).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', false, nil, nil, nil, 3).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', '--no-progress'])
       end


### PR DESCRIPTION
_https://github.com/xcpretty/xcode-install/pull/269 brought up to date with master_ (closes #269)

Brief

Our company uses fastlane extensively (including xcversion) in a distributed environment, with each developer provided their own Mac. As a result we use xcversion to install the same version of Xcode on multiple Macs, however the set up prevents "imaging" each device.

In order to prevent multiple downloads of Xcode (especially in the middle of the day when the office LAN is congested) we required the ability to "cache" Xcode DMG/XIP files in a central location. This PR provides the option to includes a base URL that contains these cached files.

Example Usage

Simply append --cache-url-base=[INSERT_URL] to the xcversion command, omitting the Xcode file name.

e.g. xcversion install 9.3 --cache-url-base=http://10.1.1.15/XcodeCache

Related

Possibly a solution for issue #198 (Resolves #198)