### PR TITLE
Remove CLAide version restriction

### DIFF
--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # CLI parsing
-  spec.add_dependency 'claide', '>= 0.9.1', '< 1.1.0'
+  spec.add_dependency 'claide', '>= 0.9.1'
 
   # contains spaceship, which is used for auth and dev portal interactions
   spec.add_dependency 'fastlane', '>= 2.1.0', '< 3.0.0'


### PR DESCRIPTION
Not sure if there should be some other restriction, e.g. `< 2.0.0`.

This should fix #452.